### PR TITLE
Remove file with UUID name from root directory

### DIFF
--- a/cdf51df4-2507-474b-9a30-c533248b6c14
+++ b/cdf51df4-2507-474b-9a30-c533248b6c14
@@ -1,1 +1,0 @@
-neo-e9c10dd8-e037-42b2-9651-19d8a32532cd-palako/nodulus


### PR DESCRIPTION
This pull request fixes #2 by removing a file with a UUID name from the root directory. The file, identified by its unique UUID, was deleted to address the issue of unnecessary files cluttering the root directory. This change helps in maintaining a cleaner project structure.