### PR TITLE
Add click/tap behavior for single move nodes

### DIFF
--- a/Assets/Scripts/View/Game/BoardAction.cs
+++ b/Assets/Scripts/View/Game/BoardAction.cs
@@ -128,7 +128,19 @@ namespace View.Game
         [MethodImpl(MethodImplOptions.Synchronized)]
         public void Play(NodeView nodeView)
         {
-            // TODO: currently does nothing, but could do something interesting perhaps
+            if (!enabled) {
+                return;
+            }
+            
+            // Get all connections from the node
+            var connections = nodeView.Node.Connections.ToList();
+            
+            // If there's exactly one connection, automatically perform that move
+            if (connections.Count == 1) {
+                var field = connections[0];
+                var direction = field.Direction;
+                Play(nodeView, direction);
+            }
         }
 
         public void HighlightAll()


### PR DESCRIPTION
This pull request fixes #9 by implementing a feature where clicking or tapping on a node with only one possible move automatically performs that move. The code changes ensure that when a node has exactly one connection, the move is executed without requiring a drag action. This enhancement improves user interaction by simplifying gameplay actions.