### PR TITLE
Change target cube color to orange

### DIFF
--- a/Assets/Scripts/View/Control/GameDef.cs
+++ b/Assets/Scripts/View/Control/GameDef.cs
@@ -28,7 +28,7 @@ namespace View.Control
         // Item Colors
         // TODO: add color themes
         public Color NodeColor = new Color32(85, 134, 171, 255);
-        public Color NodeFinalColor = new Color32(119, 231, 115, 255);
+        public Color NodeFinalColor = new Color32(255, 140, 0, 255);
         public Color ArcColor = new Color32(155, 182, 181, 255);
         public Color FieldColor = new Color32(45, 67, 75, 90);
 


### PR DESCRIPTION
This pull request fixes #11 by changing the target cube's color from light green to orange. The color code for `NodeFinalColor` in `GameDef.cs` has been updated to reflect this change, aligning with the issue's requirement to have the target cube with the checkmark appear in orange.