### PR TITLE
Change target cube color to orange

### DIFF
--- a/Assets/Scripts/View/Items/NodeView.cs
+++ b/Assets/Scripts/View/Items/NodeView.cs
@@ -19,7 +19,7 @@ namespace View.Items
         public GameObject CheckmarkPrefab;
 
         public Color NodeColor => GameDef.Get.NodeColor;
-        public Color NodeFinalColor => GameDef.Get.NodeFinalColor;
+        public Color NodeFinalColor => new Color(1f, 0.5f, 0f);
 
         private ScaleScript _nodeScale;
         private Colorizer _colorizer;


### PR DESCRIPTION
This pull request fixes #11 by updating the color of the target cube with the checkmark from light green to orange. The change is made by modifying the `NodeFinalColor` property in the `NodeView` class to use the new orange color value `(1f, 0.5f, 0f)`. This addresses the issue of the target cube color not being as desired.