### PR TITLE
Add keyboard control for cursor movement and node rotation

### DIFF
--- a/Assets/Scripts/Core/Data/Point.cs
+++ b/Assets/Scripts/Core/Data/Point.cs
@@ -51,6 +51,16 @@ namespace Core.Data
             unchecked { return (x * 397) ^ y; }
         }
 
+        public static bool operator ==(Point p1, Point p2)
+        {
+            return p1.Equals(p2);
+        }
+
+        public static bool operator !=(Point p1, Point p2)
+        {
+            return !p1.Equals(p2);
+        }
+
         public override string ToString()
         {
             return $"({x},{y})";

--- a/Assets/Scripts/View/Control/GameController.cs
+++ b/Assets/Scripts/View/Control/GameController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+¿using UnityEngine;
+using Core.Data;
 
 namespace View.Control
 {
@@ -7,10 +8,61 @@ namespace View.Control
 	/// </summary>
 	public class GameController : MonoBehaviour
 	{
+		private KeyboardInput _keyboardInput;
+
+		private void Start()
+		{
+			_keyboardInput = GetComponent<KeyboardInput>();
+		}
+
 		private void Update() 
 		{
 			if (Input.GetKeyDown(KeyCode.Escape)) {
 				Application.Quit();
+			}
+
+			if (_keyboardInput != null && _keyboardInput.enabled)
+			{
+				// Check for Shift + Arrow keys (rotation)
+				if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+				{
+					if (Input.GetKeyDown(KeyCode.UpArrow))
+					{
+						_keyboardInput.RotateNode(Direction.Up);
+					}
+					else if (Input.GetKeyDown(KeyCode.DownArrow))
+					{
+						_keyboardInput.RotateNode(Direction.Down);
+					}
+					else if (Input.GetKeyDown(KeyCode.LeftArrow))
+					{
+						_keyboardInput.RotateNode(Direction.Left);
+					}
+					else if (Input.GetKeyDown(KeyCode.RightArrow))
+					{
+						_keyboardInput.RotateNode(Direction.Right);
+					}
+				}
+				// Check for Arrow keys alone (cursor movement)
+				else
+				{
+					if (Input.GetKeyDown(KeyCode.UpArrow))
+					{
+						_keyboardInput.MoveCursor(Direction.Up);
+					}
+					else if (Input.GetKeyDown(KeyCode.DownArrow))
+					{
+						_keyboardInput.MoveCursor(Direction.Down);
+					}
+					else if (Input.GetKeyDown(KeyCode.LeftArrow))
+					{
+						_keyboardInput.MoveCursor(Direction.Left);
+					}
+					else if (Input.GetKeyDown(KeyCode.RightArrow))
+					{
+						_keyboardInput.MoveCursor(Direction.Right);
+					}
+				}
 			}
 		}
 	}

--- a/Assets/Scripts/View/Control/KeyboardInput.cs
+++ b/Assets/Scripts/View/Control/KeyboardInput.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Core.Data;
 using UnityEngine;
+using View.Items;
 using View.Game;
 
 namespace View.Control
@@ -130,16 +131,16 @@ namespace View.Control
                 switch (direction)
                 {
                     case Direction.Up:
-                        isInDirection = diff.Y > 0;
+                        isInDirection = diff.y > 0;
                         break;
                     case Direction.Down:
-                        isInDirection = diff.Y < 0;
+                        isInDirection = diff.y < 0;
                         break;
                     case Direction.Left:
-                        isInDirection = diff.X < 0;
+                        isInDirection = diff.x < 0;
                         break;
                     case Direction.Right:
-                        isInDirection = diff.X > 0;
+                        isInDirection = diff.x > 0;
                         break;
                 }
 
@@ -149,17 +150,17 @@ namespace View.Control
                 }
 
                 // Calculate distance (Manhattan distance for grid-based movement)
-                float distance = Mathf.Abs(diff.X) + Mathf.Abs(diff.Y);
+                float distance = Mathf.Abs(diff.x) + Mathf.Abs(diff.y);
 
                 // For primary axis movement, prioritize nodes that are more aligned with the direction
                 float alignmentPenalty = 0f;
                 if (direction.IsHorizontal())
                 {
-                    alignmentPenalty = Mathf.Abs(diff.Y) * 0.5f;
+                    alignmentPenalty = Mathf.Abs(diff.y) * 0.5f;
                 }
                 else if (direction.IsVertical())
                 {
-                    alignmentPenalty = Mathf.Abs(diff.X) * 0.5f;
+                    alignmentPenalty = Mathf.Abs(diff.x) * 0.5f;
                 }
 
                 float totalDistance = distance + alignmentPenalty;

--- a/Assets/Scripts/View/Control/KeyboardInput.cs
+++ b/Assets/Scripts/View/Control/KeyboardInput.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using System.Linq;
+using Core.Data;
+using UnityEngine;
+using View.Game;
+
+namespace View.Control
+{
+    /// <summary>
+    /// Handles keyboard input for cursor movement and node rotation
+    /// </summary>
+    public class KeyboardInput : MonoBehaviour
+    {
+        private BoardAction _boardAction;
+        private IDictionary<Point, NodeView> _nodeMap;
+        private NodeView _currentNode;
+        private CursorIndicator _cursorIndicator;
+
+        public void Initialize(BoardAction boardAction, IDictionary<Point, NodeView> nodeMap)
+        {
+            _boardAction = boardAction;
+            _nodeMap = nodeMap;
+
+            // Select the first node as the initial cursor position
+            if (_nodeMap != null && _nodeMap.Count > 0)
+            {
+                _currentNode = _nodeMap.Values.First();
+                UpdateCursorIndicator();
+            }
+        }
+
+        private void Update()
+        {
+            if (!enabled || _currentNode == null)
+            {
+                return;
+            }
+
+            // Check for Shift + Arrow keys (rotation)
+            if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
+            {
+                if (Input.GetKeyDown(KeyCode.UpArrow))
+                {
+                    RotateNode(Direction.Up);
+                }
+                else if (Input.GetKeyDown(KeyCode.DownArrow))
+                {
+                    RotateNode(Direction.Down);
+                }
+                else if (Input.GetKeyDown(KeyCode.LeftArrow))
+                {
+                    RotateNode(Direction.Left);
+                }
+                else if (Input.GetKeyDown(KeyCode.RightArrow))
+                {
+                    RotateNode(Direction.Right);
+                }
+            }
+            // Check for Arrow keys alone (cursor movement)
+            else
+            {
+                if (Input.GetKeyDown(KeyCode.UpArrow))
+                {
+                    MoveCursor(Direction.Up);
+                }
+                else if (Input.GetKeyDown(KeyCode.DownArrow))
+                {
+                    MoveCursor(Direction.Down);
+                }
+                else if (Input.GetKeyDown(KeyCode.LeftArrow))
+                {
+                    MoveCursor(Direction.Left);
+                }
+                else if (Input.GetKeyDown(KeyCode.RightArrow))
+                {
+                    MoveCursor(Direction.Right);
+                }
+            }
+        }
+
+        private void MoveCursor(Direction direction)
+        {
+            var nextNode = FindNextNodeInDirection(_currentNode.Position, direction);
+
+            if (nextNode != null)
+            {
+                _currentNode = nextNode;
+                UpdateCursorIndicator();
+            }
+            else
+            {
+                // No node found in that direction, trigger blink
+                if (_cursorIndicator != null)
+                {
+                    _cursorIndicator.Blink();
+                }
+            }
+        }
+
+        private void RotateNode(Direction direction)
+        {
+            if (_boardAction != null && _currentNode != null)
+            {
+                _boardAction.Play(_currentNode, direction);
+            }
+        }
+
+        private NodeView FindNextNodeInDirection(Point currentPosition, Direction direction)
+        {
+            var directionVector = direction.ToPoint();
+            NodeView closestNode = null;
+            float closestDistance = float.MaxValue;
+
+            foreach (var kvp in _nodeMap)
+            {
+                var nodePosition = kvp.Key;
+                var nodeView = kvp.Value;
+
+                // Skip the current node
+                if (nodePosition == currentPosition)
+                {
+                    continue;
+                }
+
+                // Calculate the difference vector
+                var diff = nodePosition - currentPosition;
+
+                // Check if the node is in the correct direction
+                bool isInDirection = false;
+                switch (direction)
+                {
+                    case Direction.Up:
+                        isInDirection = diff.Y > 0;
+                        break;
+                    case Direction.Down:
+                        isInDirection = diff.Y < 0;
+                        break;
+                    case Direction.Left:
+                        isInDirection = diff.X < 0;
+                        break;
+                    case Direction.Right:
+                        isInDirection = diff.X > 0;
+                        break;
+                }
+
+                if (!isInDirection)
+                {
+                    continue;
+                }
+
+                // Calculate distance (Manhattan distance for grid-based movement)
+                float distance = Mathf.Abs(diff.X) + Mathf.Abs(diff.Y);
+
+                // For primary axis movement, prioritize nodes that are more aligned with the direction
+                float alignmentPenalty = 0f;
+                if (direction.IsHorizontal())
+                {
+                    alignmentPenalty = Mathf.Abs(diff.Y) * 0.5f;
+                }
+                else if (direction.IsVertical())
+                {
+                    alignmentPenalty = Mathf.Abs(diff.X) * 0.5f;
+                }
+
+                float totalDistance = distance + alignmentPenalty;
+
+                if (totalDistance < closestDistance)
+                {
+                    closestDistance = totalDistance;
+                    closestNode = nodeView;
+                }
+            }
+
+            return closestNode;
+        }
+
+        private void UpdateCursorIndicator()
+        {
+            // Remove indicator from previous node
+            if (_cursorIndicator != null)
+            {
+                Destroy(_cursorIndicator.gameObject);
+                _cursorIndicator = null;
+            }
+
+            // Add indicator to current node
+            if (_currentNode != null)
+            {
+                _cursorIndicator = _currentNode.gameObject.AddComponent<CursorIndicator>();
+                _cursorIndicator.Show();
+            }
+        }
+
+        private void OnDisable()
+        {
+            // Hide cursor when input is disabled
+            if (_cursorIndicator != null)
+            {
+                _cursorIndicator.Hide();
+            }
+        }
+
+        private void OnEnable()
+        {
+            // Show cursor when input is enabled
+            if (_cursorIndicator != null)
+            {
+                _cursorIndicator.Show();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/View/Control/KeyboardInput.cs
+++ b/Assets/Scripts/View/Control/KeyboardInput.cs
@@ -30,57 +30,13 @@ namespace View.Control
             }
         }
 
-        private void Update()
+        public void MoveCursor(Direction direction)
         {
             if (!enabled || _currentNode == null)
             {
                 return;
             }
 
-            // Check for Shift + Arrow keys (rotation)
-            if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
-            {
-                if (Input.GetKeyDown(KeyCode.UpArrow))
-                {
-                    RotateNode(Direction.Up);
-                }
-                else if (Input.GetKeyDown(KeyCode.DownArrow))
-                {
-                    RotateNode(Direction.Down);
-                }
-                else if (Input.GetKeyDown(KeyCode.LeftArrow))
-                {
-                    RotateNode(Direction.Left);
-                }
-                else if (Input.GetKeyDown(KeyCode.RightArrow))
-                {
-                    RotateNode(Direction.Right);
-                }
-            }
-            // Check for Arrow keys alone (cursor movement)
-            else
-            {
-                if (Input.GetKeyDown(KeyCode.UpArrow))
-                {
-                    MoveCursor(Direction.Up);
-                }
-                else if (Input.GetKeyDown(KeyCode.DownArrow))
-                {
-                    MoveCursor(Direction.Down);
-                }
-                else if (Input.GetKeyDown(KeyCode.LeftArrow))
-                {
-                    MoveCursor(Direction.Left);
-                }
-                else if (Input.GetKeyDown(KeyCode.RightArrow))
-                {
-                    MoveCursor(Direction.Right);
-                }
-            }
-        }
-
-        private void MoveCursor(Direction direction)
-        {
             var nextNode = FindNextNodeInDirection(_currentNode.Position, direction);
 
             if (nextNode != null)
@@ -98,8 +54,13 @@ namespace View.Control
             }
         }
 
-        private void RotateNode(Direction direction)
+        public void RotateNode(Direction direction)
         {
+            if (!enabled || _currentNode == null)
+            {
+                return;
+            }
+
             if (_boardAction != null && _currentNode != null)
             {
                 _boardAction.Play(_currentNode, direction);
@@ -188,24 +149,6 @@ namespace View.Control
             if (_currentNode != null)
             {
                 _cursorIndicator = _currentNode.gameObject.AddComponent<CursorIndicator>();
-                _cursorIndicator.Show();
-            }
-        }
-
-        private void OnDisable()
-        {
-            // Hide cursor when input is disabled
-            if (_cursorIndicator != null)
-            {
-                _cursorIndicator.Hide();
-            }
-        }
-
-        private void OnEnable()
-        {
-            // Show cursor when input is enabled
-            if (_cursorIndicator != null)
-            {
                 _cursorIndicator.Show();
             }
         }

--- a/Assets/Scripts/View/Game/CursorIndicator.cs
+++ b/Assets/Scripts/View/Game/CursorIndicator.cs
@@ -1,0 +1,115 @@
+using System.Collections;
+using UnityEngine;
+
+namespace View.Game
+{
+    /// <summary>
+    /// Visual indicator showing which node is currently selected by keyboard control
+    /// </summary>
+    public class CursorIndicator : MonoBehaviour
+    {
+        private GameObject _indicatorLine;
+        private Material _lineMaterial;
+        private bool _isBlinking;
+
+        private const float LineWidth = 0.1f;
+        private const float LineLength = 0.8f;
+        private const float LineYOffset = -0.45f;
+        private const float BlinkDuration = 0.3f;
+        private const int BlinkCount = 2;
+
+        private void Awake()
+        {
+            CreateIndicatorLine();
+            Hide();
+        }
+
+        private void CreateIndicatorLine()
+        {
+            _indicatorLine = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            _indicatorLine.transform.SetParent(transform);
+            _indicatorLine.transform.localPosition = new Vector3(0, LineYOffset, 0);
+            _indicatorLine.transform.localRotation = Quaternion.identity;
+            _indicatorLine.transform.localScale = new Vector3(LineLength, LineWidth, LineWidth);
+
+            // Remove collider as we don't need it for visual indicator
+            var collider = _indicatorLine.GetComponent<Collider>();
+            if (collider != null)
+            {
+                Destroy(collider);
+            }
+
+            // Create white material for the line
+            _lineMaterial = new Material(Shader.Find("Standard"));
+            _lineMaterial.color = new Color(1f, 1f, 1f, 0.8f);
+            _lineMaterial.SetFloat("_Metallic", 0.5f);
+            _lineMaterial.SetFloat("_Glossiness", 0.5f);
+
+            var renderer = _indicatorLine.GetComponent<Renderer>();
+            if (renderer != null)
+            {
+                renderer.material = _lineMaterial;
+            }
+        }
+
+        /// <summary>
+        /// Shows the cursor indicator
+        /// </summary>
+        public void Show()
+        {
+            if (_indicatorLine != null)
+            {
+                _indicatorLine.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Hides the cursor indicator
+        /// </summary>
+        public void Hide()
+        {
+            if (_indicatorLine != null)
+            {
+                _indicatorLine.SetActive(false);
+            }
+        }
+
+        /// <summary>
+        /// Triggers a blink animation to indicate the cursor cannot move in the requested direction
+        /// </summary>
+        public void Blink()
+        {
+            if (!_isBlinking)
+            {
+                StartCoroutine(BlinkCoroutine());
+            }
+        }
+
+        private IEnumerator BlinkCoroutine()
+        {
+            _isBlinking = true;
+            var originalColor = _lineMaterial.color;
+
+            for (int i = 0; i < BlinkCount; i++)
+            {
+                // Fade out
+                _lineMaterial.color = new Color(originalColor.r, originalColor.g, originalColor.b, 0.2f);
+                yield return new WaitForSeconds(BlinkDuration / (BlinkCount * 2));
+
+                // Fade in
+                _lineMaterial.color = originalColor;
+                yield return new WaitForSeconds(BlinkDuration / (BlinkCount * 2));
+            }
+
+            _isBlinking = false;
+        }
+
+        private void OnDestroy()
+        {
+            if (_lineMaterial != null)
+            {
+                Destroy(_lineMaterial);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces keyboard controls to allow users to move a cursor across nodes and rotate nodes using arrow keys and shift + arrow keys, respectively. The changes include the implementation of a `KeyboardInput` class to handle these inputs and a `CursorIndicator` class to visually indicate the current node selected by the keyboard. This enhancement fixes #16 by enabling keyboard navigation and interaction with nodes, providing a more accessible and efficient user experience.